### PR TITLE
Adds foreman gem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,8 @@ gem 'responders', '2.0'
 
 gem 'active_model_serializers', github: 'rails-api/active_model_serializers', branch: '0-8-stable'
 
+gem 'foreman'
+
 # CodeClimate Reporter
 gem 'codeclimate-test-reporter', group: :test, require: nil
 gem 'simplecov', require: false, group: :test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,6 +151,8 @@ GEM
       railties (>= 3.0.0)
     faker (1.4.3)
       i18n (~> 0.5)
+    foreman (0.78.0)
+      thor (~> 0.19.1)
     formtastic (3.1.3)
       actionpack (>= 3.2.13)
     formtastic_i18n (0.3.0)
@@ -410,6 +412,7 @@ DEPENDENCIES
   devise
   factory_girl_rails
   faker
+  foreman
   formtastic
   google-webfonts-rails
   inherited_resources


### PR DESCRIPTION
The foreman gem allows devs to run all processes required to run the app from one command. `bundle exec foreman start`. This is how Heroku starts the app. Foreman knows how to start the processes by reading the `Procfile`