### PR TITLE
added required false so scss-lint works properly.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -123,6 +123,7 @@ group :development, :test do
 
   # Lints
   gem 'rubocop', '~> 0.40.0'
+  gem 'scss_lint', require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -296,6 +296,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    scss_lint (0.48.0)
+      rake (>= 0.9, < 12)
+      sass (~> 3.4.15)
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
     sidekiq (4.1.0)
@@ -422,6 +425,7 @@ DEPENDENCIES
   rspec-rails
   rubocop (~> 0.40.0)
   sass-rails (~> 5.0)
+  scss_lint
   shoulda-matchers
   sidekiq
   sidekiq-failures
@@ -439,5 +443,8 @@ DEPENDENCIES
   web-console
   webmock
 
+RUBY VERSION
+   ruby 2.3.1p112
+
 BUNDLED WITH
-   1.11.2
+   1.12.5


### PR DESCRIPTION
## Summary
Fixed the gemfile and scss lint now works properly without showing errors. The `require: false` is the real difference. scss-lint recently updated their readme where it says you must add that.
