### PR TITLE
changed devise module name for rspec

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -28,7 +28,7 @@ RSpec.configure do |config|
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
   config.infer_spec_type_from_file_location!
-  config.include Devise::TestHelpers, type: :controller
+  config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Response::JSONParser, type: :controller
   config.order = 'random'
 end


### PR DESCRIPTION
## Summary

- I got this error message when running some specs.
`DEPRECATION WARNING: [Devise] including `Devise::TestHelpers` is deprecated and will be removed from Devise. For controller tests, please include `Devise::Test::ControllerHelpers` instead.`
- This PR fix that
