### PR TITLE
Added RSpec rubocop gem

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,3 +23,22 @@ HasAndBelongsToMany:
 
 Style/FrozenStringLiteralComment:
   Enabled: false
+
+# rubocop-rspec custom configurations
+
+require: rubocop-rspec
+
+Style/VariableNumber:
+  EnforcedStyle: snake_case
+
+RSpec/ExampleLength:
+  Exclude:
+
+RSpec/AnyInstance:
+  Enabled: true
+
+RSpec/MultipleExpectations:
+  Enabled: false
+
+RSpec/NestedGroups:
+  Max: 3

--- a/Gemfile
+++ b/Gemfile
@@ -105,7 +105,9 @@ group :development, :test do
   gem 'faker'
 
   # Lints
-  gem 'rubocop'
+  gem 'rubocop', '0.50.0'
+  gem 'rubocop-rspec', '1.10.0'
+
   gem 'scss_lint', require: false
 
   # Static analysis for security vulnerabilities

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -277,6 +277,7 @@ GEM
       ast
       ruby-ll (~> 2.1)
     orm_adapter (0.5.0)
+    parallel (1.12.0)
     parser (2.3.3.1)
       ast (~> 2.2)
     path_expander (1.0.1)
@@ -331,7 +332,8 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rainbow (2.2.1)
+    rainbow (2.2.2)
+      rake
     rake (12.0.0)
     ransack (1.8.2)
       actionpack (>= 3.0)
@@ -371,16 +373,19 @@ GEM
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    rubocop (0.47.1)
+    rubocop (0.50.0)
+      parallel (~> 1.10)
       parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)
-      rainbow (>= 1.99.1, < 3.0)
+      rainbow (>= 2.2.2, < 3.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
+    rubocop-rspec (1.10.0)
+      rubocop (>= 0.42.0)
     ruby-ll (2.1.2)
       ansi
       ast
-    ruby-progressbar (1.8.1)
+    ruby-progressbar (1.8.3)
     ruby_parser (3.8.4)
       sexp_processor (~> 4.1)
     rubycritic (3.1.3)
@@ -461,7 +466,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (3.0.4)
       execjs (>= 0.3.0, < 3)
-    unicode-display_width (1.1.3)
+    unicode-display_width (1.3.0)
     uniform_notifier (1.10.0)
     virtus (1.0.5)
       axiom-types (~> 0.1)
@@ -535,7 +540,8 @@ DEPENDENCIES
   rollbar
   rspec-mocks
   rspec-rails
-  rubocop
+  rubocop (= 0.50.0)
+  rubocop-rspec (= 1.10.0)
   rubycritic
   sass-rails (~> 5.0)
   scss_lint

--- a/spec/features/example_test_spec.rb
+++ b/spec/features/example_test_spec.rb
@@ -5,7 +5,9 @@ feature 'Test feature' do
     puts 'Dummy Background'
   end
 
+  let!(:truly) { true }
+
   scenario 'Test Home Rendering' do
-    expect(true).to be(true)
+    expect(truly).to be(true)
   end
 end


### PR DESCRIPTION
## Summary

- Added [rubocop-rspec gem](https://github.com/backus/rubocop-rspec)
- Added the [rules](https://github.com/backus/rubocop-rspec/tree/master/lib/rubocop/cop/rspec) that may be excluded in some situations
- Updated rubocop to 0.50.0