### PR TITLE
Parsed Response checks for body

### DIFF
--- a/spec/support/parsed_response_helper.rb
+++ b/spec/support/parsed_response_helper.rb
@@ -1,7 +1,7 @@
 module Response
   module JSONParser
     def response_body
-      ActiveSupport::JSON.decode(response.body) if response.present?
+      ActiveSupport::JSON.decode(response.body) if response.present? && response.body.present?
     end
   end
 end


### PR DESCRIPTION
## Summary

To avoid having a response with body `nil` parsed as `''`, I added a check to also see if there is any content to the response's body, this avoids `JSON::ParserError: 743: unexpected token at ''` error

