### PR TITLE
Fixed Rspec file fixtures path config

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -25,7 +25,7 @@ Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 RSpec.configure do |config|
   config.include ActionDispatch::TestProcess
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  config.file_fixture_path = Rails.root.join('spec', 'support', 'fixtures')
 
   config.infer_spec_type_from_file_location!
   config.include Devise::Test::ControllerHelpers, type: :controller


### PR DESCRIPTION
## Summary

* Fixed config key we should overwrite to configure the path of the file fixtures. (For more info see: https://relishapp.com/rspec/rspec-rails/v/3-6/docs/file-fixture).
* Changed default path of file fixtures to encourage the idea of putting the fixtures inside de `spec/support/` folder.
