### PR TITLE
Added common shared examples

### DIFF
--- a/spec/support/shared_examples/bad_request_when_does_not_exist.rb
+++ b/spec/support/shared_examples/bad_request_when_does_not_exist.rb
@@ -1,0 +1,12 @@
+shared_examples 'bad request when it does not exist' do
+  let(:req) { get :show, params: { id: invalid_id } }
+
+  context "when model doesn't exist" do
+    let(:invalid_id) { 0 }
+
+    it 'returns status code bad request' do
+      req
+      expect(response).to have_http_status(:bad_request)
+    end
+  end
+end

--- a/spec/support/shared_examples/basic_creation_endpoint.rb
+++ b/spec/support/shared_examples/basic_creation_endpoint.rb
@@ -1,0 +1,17 @@
+shared_examples 'basic creation endpoint' do
+  it 'creates the model' do
+    expect { req }.to change { model_klass.count }.by 1
+  end
+
+  it 'returns status code created', dictum: DICTUM_CREATE_DESCRIPTION do
+    req
+    expect(response).to have_http_status(:created)
+  end
+
+  it 'returns the correct schema for the model' do
+    if schema_name
+      req
+      expect(response).to match_response_schema(schema_name, strict: true)
+    end
+  end
+end

--- a/spec/support/shared_examples/basic_destroy_endpoint.rb
+++ b/spec/support/shared_examples/basic_destroy_endpoint.rb
@@ -1,0 +1,19 @@
+shared_examples 'basic destroy endpoint' do
+  it 'destroys the model' do
+    expect { req }.to change { model_klass.count }.by(-1)
+  end
+
+  it 'returns status code ok', dictum: DICTUM_DESTROY_DESCRIPTION do
+    req
+    expect(response).to have_http_status(:ok)
+  end
+
+  context 'when sending invalid id' do
+    let(:model_id) { 0 }
+
+    it 'returns status bad request' do
+      req
+      expect(response).to have_http_status(:bad_request)
+    end
+  end
+end

--- a/spec/support/shared_examples/basic_show_endpoint.rb
+++ b/spec/support/shared_examples/basic_show_endpoint.rb
@@ -1,0 +1,22 @@
+shared_examples 'basic show endpoint' do
+  let(:expected_key) { 'id' }
+  let(:req)          { get :show, params: { id: model_id } }
+
+  before do
+    req
+  end
+
+  context 'when the model exists' do
+    it 'returns status code ok', dictum: DICTUM_SHOW_DESCRIPTION do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns the correct schema for model' do
+      expect(response).to match_response_schema(schema_name, strict: true)
+    end
+
+    it 'returns the desired model' do
+      expect(response_body[expected_key]).to eq model_id
+    end
+  end
+end

--- a/spec/support/shared_examples/basic_update_endpoint.rb
+++ b/spec/support/shared_examples/basic_update_endpoint.rb
@@ -1,0 +1,11 @@
+shared_examples 'basic update endpoint' do
+  it 'returns status code ok', dictum: DICTUM_UPDATE_DESCRIPTION do
+    req
+    expect(response).to have_http_status(:ok)
+  end
+
+  it 'returns the correct schema for article' do
+    req
+    expect(response).to match_response_schema(schema_name, strict: true)
+  end
+end

--- a/spec/support/shared_examples/forbidden_for_not_owners.rb
+++ b/spec/support/shared_examples/forbidden_for_not_owners.rb
@@ -1,0 +1,12 @@
+shared_examples 'forbidden for not owners' do
+  let!(:not_owner) { create(:user) }
+
+  before do
+    sign_in not_owner
+  end
+
+  it 'returns status code forbidden' do
+    req
+    expect(response).to have_http_status(:forbidden)
+  end
+end

--- a/spec/support/shared_examples/unauthorized_when_not_logged_in.rb
+++ b/spec/support/shared_examples/unauthorized_when_not_logged_in.rb
@@ -1,0 +1,8 @@
+shared_examples 'unauthorized when not logged in' do
+  context 'when the user is not logged in' do
+    it 'returns status code unauthorized' do
+      req
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Added basic common shared examples

## Usage examples

```
# Show endpoints
it_behaves_like 'basic show endpoint' do
  let(:model_id)    { article.id }
  let(:schema_name) { 'article' }
end

it_behaves_like 'bad request when it does not exist'

# Create endpoints
context 'when the user is logged in' do
  it_behaves_like 'basic creation endpoint' do
    let(:model_klass) { Article }
    let(:schema_name) { 'article' }
  end
end

it_behaves_like 'unauthorized when not logged in'

# Destroy endpoints
context 'when user is logged in' do
  before do
    sign_in user
  end

  it_behaves_like 'basic destroy endpoint' do
    let(:model_klass) { Like }
  end
end

it_behaves_like 'forbidden for not owners'

it_behaves_like 'unauthorized when not logged in'

# Update endpoints
it_behaves_like 'basic update endpoint' do
  let(:schema_name) { 'chapter' }
end
```
