### PR TITLE
Rubocop namespace fix

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,7 +28,7 @@ Style/FrozenStringLiteralComment:
 
 require: rubocop-rspec
 
-Style/VariableNumber:
+Naming/VariableNumber:
   EnforcedStyle: snake_case
 
 RSpec/ExampleLength:


### PR DESCRIPTION
## Summary

- Changed namespace for the VariableNumber cop. It was modified in the 0.50 version of Rubocop, which is the one we are using right now. 
Doc here: http://www.rubydoc.info/gems/rubocop/0.50.0/RuboCop/Cop/Naming/VariableNumber
