### PR TITLE
Exclude blocklength cop for tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,10 @@ LineLength:
 HasAndBelongsToMany:
   Enabled: false
 
+Metrics/BlockLength:
+  Exclude:
+    - spec/**/*
+
 Style/FrozenStringLiteralComment:
   Enabled: false
 


### PR DESCRIPTION
## Summary

- Exclude blocklength cop for tests
