### PR TITLE
Set faker seed to be the same seed as rspec.

### DIFF
--- a/spec/support/spec_helper.rb
+++ b/spec/support/spec_helper.rb
@@ -6,6 +6,8 @@ require 'faker'
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
 
+  Faker::Config.random = Random.new(config.seed)
+
   config.before(:all) do
     FactoryBot.reload
   end


### PR DESCRIPTION
## Summary
Based on:
https://github.com/stympy/faker#deterministic-random
and
https://github.com/rspec/rspec-core/issues/2116

Faker will now initialize with same seed as rspec. When replicating a test with the `--seed` option the exact same data will be used by the Faker gem.