### PR TITLE
Errase scss-lint from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ before_script:
 script:
   - bundle exec rspec spec -fd
   - bundle exec rubocop app spec -R --format simple
-  - bundle exec scss-lint app/assets/stylesheets/
 
 #notifications:
 #  email:


### PR DESCRIPTION
## Summary
 - Errase scss-lint from travis config  file (Gem not present in the API version of the bootstrap)

## Notes

- Is it worth to keep **database.travis.yml** and **travis.yml** file even though Jenkins configuration files are already present in the project ?

