### PR TITLE
App controller mods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ before_script:
 script:
   - bundle exec rspec spec -fd
   - bundle exec rubocop app spec -R --format simple
-  - bundle exec scss-lint app/assets/stylesheets/
 
 #notifications:
 #  email:

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,4 @@
-class ApplicationController < ActionController::Base
-  protect_from_forgery with: :null_session
-
+class ApplicationController < ActionController::API
   # i18n configuration. See: http://guides.rubyonrails.org/i18n.html
   before_action :set_locale
 


### PR DESCRIPTION
## Summary

- Make ApplicationController inherit from ActionController::API read [this](https://api.rubyonrails.org/v5.0.1/classes/ActionController/API.html)
- protect_from_forgery with: :null_session not necessary anymore

