### PR TITLE
Mimemagic fix plus readme fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,7 +159,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.1)

--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ You can skip the hook by adding `--no-verify` to your `git push`.
 - Install [Bundler](http://bundler.io/).
 
 ```bash
-  gem install bundler --no-ri --no-rdoc
+  gem install bundler --no-document
   rbenv rehash
 ```
 - Install basic dependencies if you are using Ubuntu:
 
 ```bash
-  sudo apt-get install build-essential libpq-dev nodejs
+  sudo apt install build-essential libpq-dev nodejs
 ```
 
 - Install all the gems included in the project.

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -6,6 +6,6 @@
 
 [Change!] Show the screenshots of the views you modified.
 
-## Trello Card
+## Jira Issue
 
-[Change!] Link to the associated Trello card.
+[Change!] Link to the associated Jira issue.


### PR DESCRIPTION
## Summary

Fix critical issue with mimemagic gem which causes bundler to fail when running `bundle install`.
Also, `--no-doc --no-ri` is no longer valid and has been replaced with `--no-document`.
