### PR TITLE
Update and add multiple gems

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,6 @@
  # This is the configuration used to check the rubocop source code.
+inherit_gem:
+  test-prof: config/rubocop-rspec.yml
 
 AllCops:
   Exclude:
@@ -8,6 +10,7 @@ AllCops:
     - docs/**/*
     - config/**/*
     - bin/**/*
+    - node_modules/**/*
 
 Style/Documentation:
   Enabled: false
@@ -30,6 +33,7 @@ Style/FrozenStringLiteralComment:
 require:
   - rubocop-rails
   - rubocop-rspec
+  - rubocop-performance
 
 Naming/VariableNumber:
   EnforcedStyle: snake_case

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'pg', '~> 1.1'
 # Use Puma as the app server
 gem 'puma', '~> 4.3.5'
 
-gem 'therubyracer', platforms: :ruby
+gem 'mini_racer', '~> 0.4.0'
 
 # Authentication
 gem 'devise_token_auth', '~> 1.0'
@@ -46,6 +46,8 @@ group :development do
   # Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.1'
+  # Generate Entity-Relationship Diagrams
+  gem 'rails-erd', require: false
 end
 
 group :development, :test do
@@ -62,8 +64,9 @@ group :development, :test do
 
   # Lints
   gem 'rubocop', '~> 0.75.1', require: false
-  gem 'rubocop-rails', '~> 2.3.2', require: false
-  gem 'rubocop-rspec', '~> 1.36.0'
+  gem 'rubocop-rails', '~> 2.5.2', require: false
+  gem 'rubocop-rspec', '~> 1.41.0', require: false
+  gem 'rubocop-performance', '~> 1.6.0', require: false
 
   # Static analysis for security vulnerabilities
   gem 'brakeman', require: false
@@ -83,4 +86,7 @@ group :test do
   gem 'simplecov', require: false
 
   gem 'rack-test', require: 'rack/test'
+
+  # Analyze test performance
+  gem 'test-prof', '~> 1.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,7 @@ GEM
       xpath (~> 3.2)
     case_transform (0.2)
       activesupport
+    choice (0.2.0)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.1.6)
@@ -147,7 +148,7 @@ GEM
     kwalify (0.7.2)
     launchy (2.5.0)
       addressable (~> 2.7)
-    libv8 (3.16.14.19)
+    libv8-node (15.14.0.1)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -164,6 +165,8 @@ GEM
       rake
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
+    mini_racer (0.4.0)
+      libv8-node (~> 15.14.0.0)
     minitest (5.14.1)
     nio4r (2.5.2)
     nokogiri (1.10.9)
@@ -210,6 +213,11 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
+    rails-erd (1.6.1)
+      activerecord (>= 4.2)
+      activesupport (>= 4.2)
+      choice (~> 0.2.0)
+      ruby-graphviz (~> 1.2)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
     railties (6.0.3.1)
@@ -229,11 +237,11 @@ GEM
       parser (>= 2.5.0.0, < 2.8, != 2.5.1.1)
       psych (~> 3.1.0)
       rainbow (>= 2.0, < 4.0)
-    ref (2.0.0)
     regexp_parser (1.7.1)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    rexml (3.2.5)
     rollbar (2.25.0)
     rspec-core (3.9.2)
       rspec-support (~> 3.9.3)
@@ -259,11 +267,16 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
-    rubocop-rails (2.3.2)
+    rubocop-performance (1.6.1)
+      rubocop (>= 0.71.0)
+    rubocop-rails (2.5.2)
+      activesupport
       rack (>= 1.1)
       rubocop (>= 0.72.0)
-    rubocop-rspec (1.36.0)
+    rubocop-rspec (1.41.0)
       rubocop (>= 0.68.1)
+    ruby-graphviz (1.2.5)
+      rexml
     ruby-progressbar (1.10.1)
     ruby_parser (3.14.2)
       sexp_processor (~> 4.9)
@@ -308,9 +321,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    therubyracer (0.12.3)
-      libv8 (~> 3.16.14.15)
-      ref
+    test-prof (1.0.5)
     thor (1.0.1)
     thread_safe (0.3.6)
     tty-which (0.4.2)
@@ -356,6 +367,7 @@ DEPENDENCIES
   faker
   health_check (~> 3.0)
   listen (~> 3.2.0)
+  mini_racer (~> 0.4.0)
   omniauth
   pg (~> 1.1)
   puma (~> 4.3.5)
@@ -364,11 +376,13 @@ DEPENDENCIES
   rack-cors (~> 1.0.3)
   rack-test
   rails (~> 6.0.0)
+  rails-erd
   rollbar
   rspec-rails
   rubocop (~> 0.75.1)
-  rubocop-rails (~> 2.3.2)
-  rubocop-rspec (~> 1.36.0)
+  rubocop-performance (~> 1.6.0)
+  rubocop-rails (~> 2.5.2)
+  rubocop-rspec (~> 1.41.0)
   rubycritic
   shoulda-matchers
   sidekiq (~> 6.0.2)
@@ -377,7 +391,7 @@ DEPENDENCIES
   simplecov
   spring
   spring-watcher-listen (~> 2.0.1)
-  therubyracer
+  test-prof (~> 1.0)
   webmock
   wor-paginate (~> 0.1.8)
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,11 +2,11 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 


### PR DESCRIPTION
## Summary

- Replaces `therubyracer` (not updated since 2017 and prone to failure) with more recent `mini_racer` gem, which also allows for easier updating of v8. It's even possible none of these gems is even required.
- Update rubocop cops
- Add `rubocop-performance` cop
- Add `rails-erd` to generate Entity-Relationship diagrams
- Add `test-prof` to evaluate spec performance
