### PR TITLE
Fix TimeHelper not included in spec_helper.rb

### DIFF
--- a/spec/support/spec_helper.rb
+++ b/spec/support/spec_helper.rb
@@ -2,6 +2,7 @@ require 'simplecov'
 SimpleCov.start
 require 'factory_bot'
 require 'faker'
+require 'active_support/testing/time_helpers'
 
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods


### PR DESCRIPTION
## Summary

Fix the following issue:

```
An error occurred while loading ./spec/models/admin_user_spec.rb.
Failure/Error: config.include ActiveSupport::Testing::TimeHelpers

NameError:
  uninitialized constant ActiveSupport::Testing
# ./spec/support/spec_helper.rb:8:in `block in <top (required)>'
# ./spec/support/spec_helper.rb:6:in `<top (required)>'
# ./spec/rails_helper.rb:2:in `require'
# ./spec/rails_helper.rb:2:in `<top (required)>'
# ./spec/models/admin_user_spec.rb:1:in `require'
# ./spec/models/admin_user_spec.rb:1:in `<top (required)>'
No examples found.


Finished in 0.00003 seconds (files took 1.54 seconds to load)
0 examples, 0 failures, 1 error occurred outside of examples

Coverage report generated for RSpec to /Users/wolox/project/coverage. 0 / 0 LOC (100.0%) covered.
SimpleCov failed with exit 1
```
